### PR TITLE
env exporters round 2 (wip)

### DIFF
--- a/jobs/bosh_tsdb_exporter/templates/bin/bosh_tsdb_exporter_ctl
+++ b/jobs/bosh_tsdb_exporter/templates/bin/bosh_tsdb_exporter_ctl
@@ -21,6 +21,10 @@ case $1 in
     pid_guard ${PIDFILE} "bosh_tsdb_exporter"
     echo $$ > ${PIDFILE}
 
+    <% if_p('bosh_tsdb_exporter.web.auth_password') do |auth_password| %>
+    export BOSH_TSDB_EXPORTER_WEB_AUTH_PASSWORD="<%= auth_password %>"
+    <% end %>
+
     exec bosh_tsdb_exporter \
       <% if_p('bosh_tsdb_exporter.log_format') do |log_format| %> \
       --log.format="<%= log_format %>" \
@@ -39,9 +43,6 @@ case $1 in
       <% end %> \
       <% if_p('bosh_tsdb_exporter.web.auth_username') do |auth_username| %> \
       --web.auth.username="<%= auth_username %>" \
-      <% end %> \
-      <% if_p('bosh_tsdb_exporter.web.auth_password') do |auth_password| %> \
-      --web.auth.password="<%= auth_password %>" \
       <% end %> \
       <% if_p('bosh_tsdb_exporter.web.tls_cert', 'bosh_tsdb_exporter.web.tls_key') do %> \
       --web.tls.cert_file="/var/vcap/jobs/bosh_tsdb_exporter/config/web_tls_cert.pem" \

--- a/jobs/credhub_exporter/templates/bin/credhub_exporter_ctl
+++ b/jobs/credhub_exporter/templates/bin/credhub_exporter_ctl
@@ -46,10 +46,14 @@ case $1 in
       end
     %>
 
+    export CREDHUB_EXPORTER_CLIENT_SECRET="<%= p('credhub_exporter.credhub.client_secret') %>"
+    <% if_p('credhub_exporter.web.auth_password') do |auth_password| %>
+    export CREDHUB_EXPORTER_WEB_AUTH_PASSWORD="<%= auth_password %>"
+    <% end %>
+
     exec credhub_exporter \
       --credhub.api-url="<%= url %>" \
       --credhub.client-id="<%= p('credhub_exporter.credhub.client_id') %>" \
-      --credhub.client-secret="<%= p('credhub_exporter.credhub.client_secret') %>" \
       <% if not ca_certs.empty? %> \
       --credhub.ca-certs-path="/var/vcap/jobs/credhub_exporter/config/credhub_tls_ca_cert.pem" \
       <% end %> \
@@ -82,9 +86,6 @@ case $1 in
       <% end %> \
       <% if_p('credhub_exporter.web.auth_username') do |auth_username| %> \
       --web.auth.username="<%= auth_username %>" \
-      <% end %> \
-      <% if_p('credhub_exporter.web.auth_password') do |auth_password| %> \
-      --web.auth.password="<%= auth_password %>" \
       <% end %> \
       <% if_p('credhub_exporter.web.tls_cert', 'credhub_exporter.web.tls_key') do %> \
       --web.tls.cert_file="/var/vcap/jobs/credhub_exporter/config/web_tls_cert.pem" \

--- a/jobs/redis_exporter/templates/bin/redis_exporter_ctl
+++ b/jobs/redis_exporter/templates/bin/redis_exporter_ctl
@@ -21,6 +21,10 @@ case $1 in
     pid_guard ${PIDFILE} "redis_exporter"
     echo $$ > ${PIDFILE}
 
+    <% if_p('redis_exporter.redis.password') do |password| %>
+    export REDIS_PASSWORD="<%= password %>"
+    <% end %>
+
     exec redis_exporter \
       <% if_p('redis_exporter.redis.check_keys') do |check_keys| %> \
       -check-keys="<%= check_keys %>" \
@@ -54,9 +58,6 @@ case $1 in
       <% end %> \
       <% if_p('redis_exporter.redis.address') do |address| %> \
       -redis.addr="<%= address %>" \
-      <% end %> \
-      <% if_p('redis_exporter.redis.password') do |password| %> \
-      -redis.password="<%= password %>" \
       <% end %> \
       <% if_p('redis_exporter.redis.script') do |script| %> \
       -script="/var/vcap/jobs/redis_exporter/config/script" \

--- a/jobs/shield_exporter/templates/bin/shield_exporter_ctl
+++ b/jobs/shield_exporter/templates/bin/shield_exporter_ctl
@@ -42,10 +42,15 @@ case $1 in
     export SHIELD_TRACE="<%= trace %>"
     <% end %>
 
+    export SHIELD_EXPORTER_SHIELD_PASSWORD="<%= p('shield_exporter.shield.password') %>"
+    
+    <% if_p('shield_exporter.web.auth_password') do |auth_password| %>
+    export SHIELD_EXPORTER_WEB_AUTH_PASSWORD="<%= auth_password %>"
+    <% end %>
+
     exec shield_exporter \
       --shield.backend_url="<%= p('shield_exporter.shield.backend_url') %>" \
       --shield.username="<%= p('shield_exporter.shield.username') %>" \
-      --shield.password="<%= p('shield_exporter.shield.password') %>" \
       <% if_p('shield_exporter.filter.collectors') do |collectors| %> \
       --filter.collectors="<%= collectors %>" \
       <% end %> \
@@ -65,9 +70,6 @@ case $1 in
       <% end %> \
       <% if_p('shield_exporter.web.auth_username') do |auth_username| %> \
       --web.auth.username="<%= auth_username %>" \
-      <% end %> \
-      <% if_p('shield_exporter.web.auth_password') do |auth_password| %> \
-      --web.auth.password="<%= auth_password %>" \
       <% end %> \
       <% if_p('shield_exporter.web.tls_cert', 'shield_exporter.web.tls_key') do %> \
       --web.tls.cert_file="/var/vcap/jobs/shield_exporter/config/web_tls_cert.pem" \


### PR DESCRIPTION
- [ ] ~~[bosh_exporter](https://github.com/bosh-prometheus/bosh_exporter#flags)~~ other PR
- [x] [bosh_tsdb_exporter](https://github.com/bosh-prometheus/bosh_tsdb_exporter#flags)
- [ ] ~~[collectd_exporter](https://github.com/prometheus/collectd_exporter)~~ N/A
- [ ] ~~[consul_exporter](https://github.com/prometheus/consul_exporter#environment-variables)~~ N/A
- [x] [credhub_exporter](https://github.com/orange-cloudfoundry/credhub_exporter#flags)
- [ ] ~~elasticsearch_exporter~~ N/A
- [x] ~~[firehose_exporter](https://github.com/bosh-prometheus/firehose_exporter#flags)~~ other PR
- [ ] ~~graphite_exporter~~ N/A
- [ ] ~~haproxy_exporter~~ N/A
- [ ] ~~influxdb_exporter~~ N/A
- [ ] ~~kube-state-metrics exporter~~ N/A
- [ ] ~~memcached exporter~~ N/A
- [ ] ~~mongodb_exporter~~ [doesn't appear as though the mongodb exporter supports being passed creds via env?](https://github.com/dcu/mongodb_exporter/blob/8f53431089a13bc46f4f86533451c01b60582478/mongodb_exporter.go#L49)
- [ ] ~~mysqld_exporter~~ already done 
- [ ] ~~nats_exporter~~ N/A
- [ ] ~~postgres_exporter~~ N/A
- [ ] ~~[rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter#configuration)~~ already done
- [x] [redis_exporter](https://github.com/oliver006/redis_exporter#flags)
- [x] [shield_experort](https://github.com/bosh-prometheus/shield_exporter#flags)
- [ ] ~~[stackdriver+exporter](https://github.com/frodenas/stackdriver_exporter#flags)~~ N/A
- [ ] ~~statsd_exporter~~ N/A
- [ ] ~~vault_exporter~~ N/A
